### PR TITLE
Isolate IdP loading failures to prevent single-provider outages

### DIFF
--- a/lib/samly/idp_data.ex
+++ b/lib/samly/idp_data.ex
@@ -92,10 +92,21 @@ defmodule Samly.IdpData do
   @type id :: binary()
 
   @spec load_providers([map], %{required(id()) => %SpData{}}) ::
-          %{required(id()) => %IdpData{}} | no_return()
+          %{required(id()) => %IdpData{}}
   def load_providers(prov_config, service_providers) do
     prov_config
-    |> Enum.map(fn idp_config -> load_provider(idp_config, service_providers) end)
+    |> Enum.flat_map(fn idp_config ->
+      try do
+        [load_provider(idp_config, service_providers)]
+      rescue
+        error ->
+          Logger.error(
+            "[Samly] Failed to load identity provider #{inspect(idp_config[:id])}: #{Exception.message(error)}"
+          )
+
+          []
+      end
+    end)
     |> Enum.filter(fn idp_data -> idp_data.valid? end)
     |> Enum.map(fn idp_data -> {idp_data.id, idp_data} end)
     |> Enum.into(%{})

--- a/test/data/unpadded_cert_idp_metadata.xml
+++ b/test/data/unpadded_cert_idp_metadata.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="http://samly.idp:8082/simplesaml/saml2/idp/metadata.php">
+  <md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol" WantAuthnRequestsSigned="true">
+    <md:KeyDescriptor use="signing">
+      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:X509Data>
+          <ds:X509Certificate>MIIF1TCCA72gAwIBAgIJAKdEDzxP3jJLMA0GCSqGSIb3DQEBCwUAMIGAMQswCQYDVQQGEwJVUzERMA8GA1UECAwITWlkbGFuZHMxEjAQBgNVBAcMCVNhZmV2aWxsZTEWMBQGA1UECgwNSUQgRmVkZXJhdGlvbjEhMB8GA1UECwwYRGVwYXJ0bWVudCBvZiBJZGVudGl0aWVzMQ8wDQYDVQQDDAZteS5pZHAwHhcNMTcwOTA5MDExNzMwWhcNMTgwOTA5MDExNzMwWjCBgDELMAkGA1UEBhMCVVMxETAPBgNVBAgMCE1pZGxhbmRzMRIwEAYDVQQHDAlTYWZldmlsbGUxFjAUBgNVBAoMDUlEIEZlZGVyYXRpb24xITAfBgNVBAsMGERlcGFydG1lbnQgb2YgSWRlbnRpdGllczEPMA0GA1UEAwwGbXkuaWRwMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA5MXY8olt62YGPQQo4UIZ8Q48lMGGSA4DhEAooSA4yjXeKcmG/aDeINkcTzA/khv1iCy3gFDnJ6T6tGvNghWFDVLWrKRzg3PO0y3+6MaJAJ5CXtCaf+EV9KNFcrt8+DFwdudkWrwEak1gM8OHUfXvOqyD1a5g+vPrSm+QiI9+W4csTDB6zQKfMjnQJnUh+W8H4ZLPX2nJAeJLFhDfE1l66pjKHxVRl8QTiflpunMRNgTBknCUxs+3ilG+4QxXEgQdjzLJCc9SjgNEdqnJHd7BfUOsbIi5qjTAM3UkoumEdrLWNRCutDQoc5m79U9m+xcZso/z1qnrgPD6WkS6FiI4QFT8y/hjBEVbrXC5DZHu7ujeE8h2P2qOLjJszdW7SnvYFOshhMWD5JHkAn+Dzcch75pzvlsxxtmCw44IpCkeqjKeO2ajrQcx/fywSaCyme6gwmiF8hdXLrezj1sO0aFJhkEPM0Yb9JRkG2G3a8ITp4+3J8FCAXeLc7MJ/kxOJYVlNESSCzFhWYeSAR7doN9+eXCZ8dQhkOTN4FRT5u9ylq7tYHfAH1YNr2MKsEGrQtn/pTyb1Q4Oqb1IVpNnDRL2C9RPUt9Lfb8V3OHd1Mx81yoylXsvttX1DiPNY/KR/QCWQkvvfNTfUHTOGj8ic6G/t1/IenZ9RzNRPFxj4GNwHNcCAwEAAaNQME4wHQYDVR0OBBYEFJQbKzk3Twp4XgV0T6W0T5lZVFDZMB8GA1UdIwQYMBaAFJQbKzk3Twp4XgV0T6W0T5lZVFDZMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggIBALFPci1AfEp5bXuPWHbGSvAi+nVBzwHRE9VDIvsq1gVibmunwqFW7DlXi9xvPwrcQHVZtj2qeSWEc6Grw6iROgunclQIwaf6//uqb7Jkj9RhuhCs58CGcSBQ5umfffC/P2JbOte2hJjTTDNVvawAhPPBQ1bn/t8Y3eTHN/srQUtVBPX2szUqy5uRlpFYlZ2Layfcg3oLHg6Ube/HhEA2mjgCjod7zGtwuwsUOpjktQCp3aPLWXKN+ImcGAChpqAm9frgBWgZv4mxKynjOw15ur3wgSEJO7DNmEdjLqz2OiLHeX0MrDyGpcid5hPj4CgCN6vngeNXBEaoK2lJHp0I5HbdIoRBcghIVm9RzpfrDdK3/Ayy+wEAqjQRCuwBUEvrqsMnmnIjYw8HE+BE3pIS8hh9SyGCOgPJmHbYkwztkrNi6RJyeHROwAoER6J/D1saCKMK63bqLW5WLXDfftg6BNXXfvPjuQyaqlsP+HOjX8wTlKwemvUS93aDxwP8YdcFLt/uw/GXpmNKY+/wsymMYgXkTcS0FWgNUtpH/gZUIh3AMpCi1fBi71nc0uuLUBilRMrCHI5y1Rzi0qBfAkAKyUYbUO87KRvXQ3pjmpCC/IMPFqY4hkudY9juzIcOU2auml+wBSu1c45142wdz4x//oh0N5NrVuLBe74Auy4nVOf</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </md:KeyDescriptor>
+    <md:KeyDescriptor use="encryption">
+      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:X509Data>
+          <ds:X509Certificate>MIIF1TCCA72gAwIBAgIJAKdEDzxP3jJLMA0GCSqGSIb3DQEBCwUAMIGAMQswCQYDVQQGEwJVUzERMA8GA1UECAwITWlkbGFuZHMxEjAQBgNVBAcMCVNhZmV2aWxsZTEWMBQGA1UECgwNSUQgRmVkZXJhdGlvbjEhMB8GA1UECwwYRGVwYXJ0bWVudCBvZiBJZGVudGl0aWVzMQ8wDQYDVQQDDAZteS5pZHAwHhcNMTcwOTA5MDExNzMwWhcNMTgwOTA5MDExNzMwWjCBgDELMAkGA1UEBhMCVVMxETAPBgNVBAgMCE1pZGxhbmRzMRIwEAYDVQQHDAlTYWZldmlsbGUxFjAUBgNVBAoMDUlEIEZlZGVyYXRpb24xITAfBgNVBAsMGERlcGFydG1lbnQgb2YgSWRlbnRpdGllczEPMA0GA1UEAwwGbXkuaWRwMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA5MXY8olt62YGPQQo4UIZ8Q48lMGGSA4DhEAooSA4yjXeKcmG/aDeINkcTzA/khv1iCy3gFDnJ6T6tGvNghWFDVLWrKRzg3PO0y3+6MaJAJ5CXtCaf+EV9KNFcrt8+DFwdudkWrwEak1gM8OHUfXvOqyD1a5g+vPrSm+QiI9+W4csTDB6zQKfMjnQJnUh+W8H4ZLPX2nJAeJLFhDfE1l66pjKHxVRl8QTiflpunMRNgTBknCUxs+3ilG+4QxXEgQdjzLJCc9SjgNEdqnJHd7BfUOsbIi5qjTAM3UkoumEdrLWNRCutDQoc5m79U9m+xcZso/z1qnrgPD6WkS6FiI4QFT8y/hjBEVbrXC5DZHu7ujeE8h2P2qOLjJszdW7SnvYFOshhMWD5JHkAn+Dzcch75pzvlsxxtmCw44IpCkeqjKeO2ajrQcx/fywSaCyme6gwmiF8hdXLrezj1sO0aFJhkEPM0Yb9JRkG2G3a8ITp4+3J8FCAXeLc7MJ/kxOJYVlNESSCzFhWYeSAR7doN9+eXCZ8dQhkOTN4FRT5u9ylq7tYHfAH1YNr2MKsEGrQtn/pTyb1Q4Oqb1IVpNnDRL2C9RPUt9Lfb8V3OHd1Mx81yoylXsvttX1DiPNY/KR/QCWQkvvfNTfUHTOGj8ic6G/t1/IenZ9RzNRPFxj4GNwHNcCAwEAAaNQME4wHQYDVR0OBBYEFJQbKzk3Twp4XgV0T6W0T5lZVFDZMB8GA1UdIwQYMBaAFJQbKzk3Twp4XgV0T6W0T5lZVFDZMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggIBALFPci1AfEp5bXuPWHbGSvAi+nVBzwHRE9VDIvsq1gVibmunwqFW7DlXi9xvPwrcQHVZtj2qeSWEc6Grw6iROgunclQIwaf6//uqb7Jkj9RhuhCs58CGcSBQ5umfffC/P2JbOte2hJjTTDNVvawAhPPBQ1bn/t8Y3eTHN/srQUtVBPX2szUqy5uRlpFYlZ2Layfcg3oLHg6Ube/HhEA2mjgCjod7zGtwuwsUOpjktQCp3aPLWXKN+ImcGAChpqAm9frgBWgZv4mxKynjOw15ur3wgSEJO7DNmEdjLqz2OiLHeX0MrDyGpcid5hPj4CgCN6vngeNXBEaoK2lJHp0I5HbdIoRBcghIVm9RzpfrDdK3/Ayy+wEAqjQRCuwBUEvrqsMnmnIjYw8HE+BE3pIS8hh9SyGCOgPJmHbYkwztkrNi6RJyeHROwAoER6J/D1saCKMK63bqLW5WLXDfftg6BNXXfvPjuQyaqlsP+HOjX8wTlKwemvUS93aDxwP8YdcFLt/uw/GXpmNKY+/wsymMYgXkTcS0FWgNUtpH/gZUIh3AMpCi1fBi71nc0uuLUBilRMrCHI5y1Rzi0qBfAkAKyUYbUO87KRvXQ3pjmpCC/IMPFqY4hkudY9juzIcOU2auml+wBSu1c45142wdz4x//oh0N5NrVuLBe74Auy4nVOf</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </md:KeyDescriptor>
+    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://samly.idp:8082/simplesaml/saml2/idp/SingleLogoutService.php"/>
+    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="http://samly.idp:8082/simplesaml/saml2/idp/SingleLogoutService.php"/>
+    <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://samly.idp:8082/simplesaml/saml2/idp/SSOService.php"/>
+    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="http://samly.idp:8082/simplesaml/saml2/idp/SSOService.php"/>
+  </md:IDPSSODescriptor>
+  <md:ContactPerson contactType="technical">
+    <md:GivenName>Jane</md:GivenName>
+    <md:SurName>Doe</md:SurName>
+    <md:EmailAddress>jane.doe@company.com</md:EmailAddress>
+  </md:ContactPerson>
+</md:EntityDescriptor>

--- a/test/samly_idp_data_test.exs
+++ b/test/samly_idp_data_test.exs
@@ -227,6 +227,20 @@ defmodule SamlyIdpDataTest do
     refute idp_data.valid?
   end
 
+  test "invalid idp metadata does not prevent other idps from loading", %{sps: sps} do
+    bad_idp_config = %{
+      id: "bad_idp",
+      sp_id: "sp1",
+      base_url: "http://samly.howto:4003/sso",
+      metadata_file: "test/data/unpadded_cert_idp_metadata.xml"
+    }
+
+    providers = IdpData.load_providers([@idp_config1, bad_idp_config], sps)
+
+    assert Map.has_key?(providers, "idp1")
+    refute Map.has_key?(providers, "bad_idp")
+  end
+
   test "invalid-idp-config-2", %{sps: sps} do
     idp_config = %{@idp_config1 | sp_id: "unknown-sp"}
     %IdpData{} = idp_data = IdpData.load_provider(idp_config, sps)


### PR DESCRIPTION
# User description
## Summary
- A single identity provider with invalid metadata (e.g. unpadded base64 cert from self-serve SSO setup) would crash `load_providers/2` entirely, preventing **all** IdPs from loading and returning 403 "unknown IdP" for every SSO request
- Wraps individual `load_provider/2` calls in `try/rescue` so failures are logged and skipped without affecting other providers
- The broken customer's SSO will still fail (as expected), but it no longer takes down everyone else

## Test plan
- [ ] Verify new test `"invalid idp metadata does not prevent other idps from loading"` passes
- [ ] Verify all existing tests continue to pass
- [ ] Test in staging with a deliberately malformed IdP metadata alongside valid ones


🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Isolates Identity Provider loading failures within <code>Samly.IdpData</code> to ensure that a single malformed provider does not prevent other valid providers from being registered. Enhances system resilience by wrapping provider initialization in a <code>try/rescue</code> block and logging specific failures instead of allowing them to propagate.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/dscout/samly/4?tool=ast&topic=Resilience+Testing>Resilience Testing</a>
        </td><td>Adds a new test case and a sample malformed XML metadata file to verify that invalid certificates do not block the loading of other valid Identity Providers.<details><summary>Modified files (2)</summary><ul><li>test/data/unpadded_cert_idp_metadata.xml</li>
<li>test/samly_idp_data_test.exs</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>mm@idyll.io</td><td>Get-attestation-from-e...</td><td>January 29, 2024</td></tr>
<tr><td>rpylipow@gmail.com</td><td>Add-a-custom-consume-url</td><td>December 06, 2023</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/dscout/samly/4?tool=ast&topic=Error+Isolation>Error Isolation</a>
        </td><td>Implements error isolation in <code>load_providers/2</code> using <code>Enum.flat_map</code> and a <code>try/rescue</code> block to skip failing IdPs while logging the error.<details><summary>Modified files (1)</summary><ul><li>lib/samly/idp_data.ex</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>aj-foster</td><td>Fix-record-types-in-Id...</td><td>April 19, 2024</td></tr>
<tr><td>mm@idyll.io</td><td>Add-debug-mode-that-di...</td><td>March 20, 2024</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/dscout/samly/4?tool=ast>(Baz)</a>.